### PR TITLE
Link patterns produce a bad html in nested list

### DIFF
--- a/weeklyupdates/post.py
+++ b/weeklyupdates/post.py
@@ -5,7 +5,7 @@ import markdown2
 import re
 
 link_patterns = (
-    (re.compile(r'(?<!")(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
+    (re.compile(r'(?<![">])(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
     (re.compile(r'bug[\s:#]+(\d{3,7})\b', re.I), r'https://bugzilla.mozilla.org/show_bug.cgi?id=\1'),
 )
 


### PR DESCRIPTION
Looks at this example:

```
* li1
  * li2
  * http://link.reference.com
```

The rendering with markdown2 ( tested with 2.2.1 and 2.3.1) produces a bad syntax HTML code:

``` html
<ul>
<li>li1
<ul>
<li>li2</li>
<li><a href="http://link.reference.com"><a href="http://link.reference.com</a></li>">http://link.reference.com</a></li></a>
</ul></li>
</ul>
```

Check this particular line:

``` html
<li><a href="http://link.reference.com"><a href="http://link.reference.com</a></li>">http://link.reference.com</a></li></a>
```

The this is a synthetic reduction of the code on the post.py file:

``` python
import re
import markdown2

link_patterns = (
    (re.compile(r'(?<!")(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
)

md = markdown2.Markdown(html4tags=True, tab_width=2,
                         extras=['link-patterns',
                                 'cuddled-lists',
                                 'code-friendly'],
                         link_patterns=link_patterns)


a = '''
* li1
  * li2
  * http://link.reference.com
'''

print (md.convert(a))
```

This is a recursion problem. The link patterns recognition is executed for each nested list and applied over all the entire text block. Anyway, you could fix it appling this one-line patch:

``` diff
diff --git a/weeklyupdates/post.py b/weeklyupdates/post.py
index 9c74354..8f73b1e 100755
--- a/weeklyupdates/post.py
+++ b/weeklyupdates/post.py
@@ -5,7 +5,7 @@ import markdown2
 import re

 link_patterns = (
-    (re.compile(r'(?<!")(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
+    (re.compile(r'(?<![">])(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
     (re.compile(r'bug[\s:#]+(\d{3,7})\b', re.I), r'https://bugzilla.mozilla.org/show_bug.cgi?id=\1'),
 ) 

```

; this patch take care about if the URL is preceded by '>', then it assumes the link is into a HTML tag.
