### PR TITLE
markdown link patterns can be customized by configfile

### DIFF
--- a/markdown_link_patterns.config.sample
+++ b/markdown_link_patterns.config.sample
@@ -1,0 +1,2 @@
+/(?<![">])(https?://.*?(?=[\s\]\)\|]|$))/i   \1
+/bug[\s:#]+(\d{3,7})\b/i                     https://bugzilla.mozilla.org/show_bug.cgi?id=\1

--- a/weeklyupdates/post.py
+++ b/weeklyupdates/post.py
@@ -1,13 +1,60 @@
+import os
 import datetime
 from genshi.filters import HTMLSanitizer
 from genshi.input import HTML, ParseError
 import markdown2
 import re
 
-link_patterns = (
-    (re.compile(r'(?<!")(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
-    (re.compile(r'bug[\s:#]+(\d{3,7})\b', re.I), r'https://bugzilla.mozilla.org/show_bug.cgi?id=\1'),
-)
+def _regex_from_encoded_pattern(s):
+    """'foo'    -> re.compile(re.escape('foo'))
+       '/foo/'  -> re.compile('foo')
+       '/foo/i' -> re.compile('foo', re.I)
+    """
+    if s.startswith('/') and s.rfind('/') != 0:
+        # Parse it: /PATTERN/FLAGS
+        idx = s.rfind('/')
+        pattern, flags_str = s[1:idx], s[idx+1:]
+        flag_from_char = {
+            "i": re.IGNORECASE,
+            "l": re.LOCALE,
+            "s": re.DOTALL,
+            "m": re.MULTILINE,
+            "u": re.UNICODE,
+        }
+        flags = 0
+        for char in flags_str:
+            try:
+                flags |= flag_from_char[char]
+            except KeyError:
+                raise ValueError("unsupported regex flag: '%s' in '%s' "
+                                 "(must be one of '%s')"
+                                 % (char, s, ''.join(list(flag_from_char.keys()))))
+        return re.compile(s[1:idx], flags)
+    else: # not an encoded regex
+        return re.compile(re.escape(s))
+
+markdown_link_patterns_file = os.getcwd() + os.sep + "markdown_link_patterns.config"
+if os.path.isfile(markdown_link_patterns_file):
+    link_patterns = []
+    f = open(markdown_link_patterns_file)
+    try:
+        for i, line in enumerate(f.readlines()):
+            if not line.strip(): continue
+            if line.lstrip().startswith("#"): continue
+            try:
+                pat, href = line.rstrip().rsplit(None, 1)
+            except ValueError:
+                raise MarkdownError("%s:%d: invalid link pattern line: %r"
+                                        % (opts.link_patterns_file, i+1, line))
+            link_patterns.append(
+                (_regex_from_encoded_pattern(pat), href))
+    finally:
+        f.close()
+else:
+    link_patterns = (
+        (re.compile(r'(?<!")(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
+        (re.compile(r'bug[\s:#]+(\d{3,7})\b', re.I), r'https://bugzilla.mozilla.org/show_bug.cgi?id=\1'),
+    )
 
 md = markdown2.Markdown(html4tags=True, tab_width=2,
                         extras=['link-patterns',


### PR DESCRIPTION
Allows the **customization of the link patterns** in an external configuration file. By the default, if the `markdown_link_patterns.config` file is not available, the behaviour is the same that before.

The patterns link configfile follows the syntax suggested here in the markdown2's wiki: https://github.com/trentm/python-markdown2/wiki/link-patterns#link-patterns-file.

For example:

```
/(?<![">])(https?://.*?(?=[\s\]\)\|]|$))/i   \1
/bug[\s:#]+(\d{3,7})\b/i                     https://bugzilla.mozilla.org/show_bug.cgi?id=\1
/gnome#([\w]+(?:#[\w:]+)?)/i                 https://bugzilla.gnome.org/show_bug.cgi?id=\1
/crrev#([\w]+(?:#[\w:]+)?)/i                 https://crrev.com/\1
/crbug#([\w]+(?:#[\w:]+)?)/i                 https://crbug.com/\1
/webkit#([\w]+(?:#[\w:]+)?)/i                https://bugs.webkit.org/show_bug.cgi?id=\1

```
