### PR TITLE
Mozilla mode is optative - References to Mozilla can be overwritten

### DIFF
--- a/weeklyupdates.config.sample
+++ b/weeklyupdates.config.sample
@@ -11,6 +11,7 @@ smtp.server = 'mymailserver'
 smtp.username = 'mymailuser'
 smtp.password = 'mymailpassword'
 mozilla = True
+email.from = 'Mozilla Status Updates <weekly-updates@mozilla.com>'
 email.list_id = 'weekly-updates.mozilla.com'
 
 [/]

--- a/weeklyupdates.config.sample
+++ b/weeklyupdates.config.sample
@@ -13,6 +13,7 @@ smtp.password = 'mymailpassword'
 mozilla = True
 email.from = 'Mozilla Status Updates <weekly-updates@mozilla.com>'
 email.list_id = 'weekly-updates.mozilla.com'
+title = "Mozilla Status Board"
 
 [/]
 tools.sessions.timeout = 20160

--- a/weeklyupdates.config.sample
+++ b/weeklyupdates.config.sample
@@ -10,6 +10,8 @@ feed.tag.domain = 'weeklyupdates.benjamin.smedbergs.us,2009-10-05'
 smtp.server = 'mymailserver'
 smtp.username = 'mymailuser'
 smtp.password = 'mymailpassword'
+mozilla = True
+email.list_id = 'weekly-updates.mozilla.com'
 
 [/]
 tools.sessions.timeout = 20160

--- a/weeklyupdates.config.sample
+++ b/weeklyupdates.config.sample
@@ -10,6 +10,7 @@ feed.tag.domain = 'weeklyupdates.benjamin.smedbergs.us,2009-10-05'
 smtp.server = 'mymailserver'
 smtp.username = 'mymailuser'
 smtp.password = 'mymailpassword'
+avatar = True
 mozilla = True
 email.from = 'Mozilla Status Updates <weekly-updates@mozilla.com>'
 email.list_id = 'weekly-updates.mozilla.com'

--- a/weeklyupdates.config.sample
+++ b/weeklyupdates.config.sample
@@ -14,6 +14,7 @@ mozilla = True
 email.from = 'Mozilla Status Updates <weekly-updates@mozilla.com>'
 email.list_id = 'weekly-updates.mozilla.com'
 title = "Mozilla Status Board"
+urlsite = 'http://statusupdates.dev.mozaws.net/'
 
 [/]
 tools.sessions.timeout = 20160

--- a/weeklyupdates/mail.py
+++ b/weeklyupdates/mail.py
@@ -104,8 +104,10 @@ def getnags(cur):
     app = cherrypy.request.app
     list_id = app.config['weeklyupdates'].get('email.list_id',
                                               '<weekly-updates.mozilla.com>')
+    title = app.config['weeklyupdates'].get('title',
+                                            'Mozilla Status Board')
     for userid, usermail, lastpostdate in model.get_naglist(cur):
-        nag = """This is a friendly reminder from the Mozilla Status Board. """
+        nag = """This is a friendly reminder from the %s. """ % title
         if lastpostdate is None:
             nag += "You have never made a post! "
         else:

--- a/weeklyupdates/mail.py
+++ b/weeklyupdates/mail.py
@@ -106,6 +106,8 @@ def getnags(cur):
                                               '<weekly-updates.mozilla.com>')
     title = app.config['weeklyupdates'].get('title',
                                             'Mozilla Status Board')
+    url = app.config['weeklyupdates'].get('urlsite',
+                                          'http://statusupdates.dev.mozaws.net/')
     for userid, usermail, lastpostdate in model.get_naglist(cur):
         nag = """This is a friendly reminder from the %s. """ % title
         if lastpostdate is None:
@@ -115,7 +117,7 @@ def getnags(cur):
 
         nag += "Please try to post weekly to keep other informed of your work."
 
-        nag += "\n\nhttp://statusupdates.dev.mozaws.net/"
+        nag += "\n\n%s" % url
 
         print "Sending nag to %s <%s>" % (userid, usermail)
 

--- a/weeklyupdates/mail.py
+++ b/weeklyupdates/mail.py
@@ -64,6 +64,9 @@ def sendmails(messages, app=None):
         sendmails_smtp(messages, fromaddress, app)
 
 def sendpost(fromaddress, recipientlist, post):
+    app = cherrypy.request.app
+    list_id = app.config['weeklyupdates'].get('email.list_id',
+                                              '<weekly-updates.mozilla.com>')
     subject = "Status Update: %s on %s" % (post.userid, post.postdate.isoformat())
 
     messages = []
@@ -72,7 +75,7 @@ def sendpost(fromaddress, recipientlist, post):
         message = email.mime.multipart.MIMEMultipart('alternative')
         message['To'] = recipient
         message['Subject'] = subject
-        message['List-Id'] = '<weekly-updates.mozilla.com>'
+        message['List-Id'] = list_id
 
         html, text = rendermail('message.xhtml', subject, post=post)
         message.attach(email.mime.text.MIMEText(text, 'plain', 'UTF-8'))
@@ -82,10 +85,14 @@ def sendpost(fromaddress, recipientlist, post):
     sendmails(messages)
 
 def getdigest(to, subject, posts):
+    app = cherrypy.request.app
+    list_id = app.config['weeklyupdates'].get('email.list_id',
+                                              '<weekly-updates.mozilla.com>')
+
     message = email.mime.multipart.MIMEMultipart('alternative')
     message['To'] = to
     message['Subject'] = subject
-    message['List-Id'] = '<weekly-updates.mozilla.com>'
+    message['List-Id'] = list_id
 
     html, text = rendermail('messagedigest.xhtml', subject, posts=posts)
     message.attach(email.mime.text.MIMEText(text, 'plain', 'UTF-8'))
@@ -94,6 +101,9 @@ def getdigest(to, subject, posts):
     return message
 
 def getnags(cur):
+    app = cherrypy.request.app
+    list_id = app.config['weeklyupdates'].get('email.list_id',
+                                              '<weekly-updates.mozilla.com>')
     for userid, usermail, lastpostdate in model.get_naglist(cur):
         nag = """This is a friendly reminder from the Mozilla Status Board. """
         if lastpostdate is None:
@@ -110,7 +120,7 @@ def getnags(cur):
         message = email.mime.text.MIMEText(nag, 'plain', 'UTF-8')
         message['To'] = usermail
         message['Subject'] = "Please post a status report"
-        message['List-Id'] = '<weekly-updates.mozilla.com>'
+        message['List-Id'] = list_id
         yield message
 
 def getdaily(cur):

--- a/weeklyupdates/main.py
+++ b/weeklyupdates/main.py
@@ -169,7 +169,7 @@ class Root(object):
 
         return renderatom(feedposts=feedposts,
                           feedurl=cherrypy.url('/feed/%s' % userid),
-                          title="%s Updates: user %s" % (title,userid))
+                          title="%s Updates: user %s" % (title, userid))
 
     @model.requires_db
     def userteamposts(self, userid):
@@ -188,7 +188,7 @@ class Root(object):
 
         return renderatom(feedposts=teamposts,
                           feedurl=cherrypy.url('/user/%s/teamposts/feed' % userid),
-                          title="%s Updates: User Team: %s" % (title,userid))
+                          title="%s Updates: User Team: %s" % (title, userid))
 
     @require_login
     @model.requires_db

--- a/weeklyupdates/main.py
+++ b/weeklyupdates/main.py
@@ -51,10 +51,14 @@ def kwargs_to_buglist(kwargs):
 class Root(object):
     @model.requires_db
     def index(self):
+        app = cherrypy.request.app
         loginid = cherrypy.request.loginid
 
         projects = model.get_projects()
-        iteration, daysleft = model.get_current_iteration()
+        if app.config['weeklyupdates'].get('mozilla', True):
+            iteration, daysleft = model.get_current_iteration()
+        else:
+            iteration, daysleft = 0,0
 
         if loginid is None:
             team = ()
@@ -67,7 +71,10 @@ class Root(object):
             team = model.get_user_projects(loginid)
             teamposts = model.get_teamposts(loginid)
             userposts, todaypost = model.get_user_posts(loginid)
-            bugs = model.get_currentbugs(loginid, iteration)
+            if app.config['weeklyupdates'].get('mozilla', True):
+                bugs = model.get_currentbugs(loginid, iteration)
+            else:
+                bugs = None
             recent = None
 
         return render('index.xhtml', projects=projects, recent=recent, team=team, bugs=bugs,

--- a/weeklyupdates/main.py
+++ b/weeklyupdates/main.py
@@ -82,11 +82,13 @@ class Root(object):
 
     @model.requires_db
     def feed(self):
+        app = cherrypy.request.app
+        title = app.config['weeklyupdates'].get('title',"Mozilla Status Board")
         feedposts = model.get_feedposts()
 
         return renderatom(feedposts=feedposts,
                           feedurl=cherrypy.url('/feed'),
-                          title="Mozilla Status Board Updates: All Users")
+                          title="%s Updates: All Users" % title)
 
     @model.requires_db
     def login(self, **kwargs):
@@ -154,11 +156,13 @@ class Root(object):
 
     @model.requires_db
     def userpostsfeed(self, userid):
+        app = cherrypy.request.app
+        title = app.config['weeklyupdates'].get('title',"Mozilla Status Board")
         feedposts = model.get_user_feedposts(userid)
 
         return renderatom(feedposts=feedposts,
                           feedurl=cherrypy.url('/feed/%s' % userid),
-                          title="Mozilla Status Board Updates: user %s" % userid)
+                          title="%s Updates: user %s" % (title,userid))
 
     @model.requires_db
     def userteamposts(self, userid):
@@ -171,11 +175,13 @@ class Root(object):
 
     @model.requires_db
     def userteampostsfeed(self, userid):
+        app = cherrypy.request.app
+        title = app.config['weeklyupdates'].get('title',"Mozilla Status Board")
         teamposts = model.get_teamposts(userid)
 
         return renderatom(feedposts=teamposts,
                           feedurl=cherrypy.url('/user/%s/teamposts/feed' % userid),
-                          title="Mozilla Status Board Updates: User Team: %s" % userid)
+                          title="%s Updates: User Team: %s" % (title,userid))
 
     @require_login
     @model.requires_db
@@ -352,11 +358,13 @@ class Root(object):
 
     @model.requires_db
     def projectfeed(self, projectname):
+        app = cherrypy.request.app
+        title = app.config['weeklyupdates'].get('title',"Mozilla Status Board")
         posts = model.get_project_posts(projectname)
 
         return renderatom(feedposts=posts,
                           feedurl=cherrypy.url('/project/%s' % projectname),
-                          title="Mozilla Status Board Updates: Project %s" % projectname)
+                          title="%s Updates: Project %s" % (title,projectname))
 
     def markup(self):
         return render('markup.xhtml')

--- a/weeklyupdates/post.py
+++ b/weeklyupdates/post.py
@@ -5,7 +5,7 @@ import markdown2
 import re
 
 link_patterns = (
-    (re.compile(r'(?<!")(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
+    (re.compile(r'(?<![">])(https?://.*?(?=[\s\]\)\|]|$))', re.I | re.MULTILINE), r'\1'),
     (re.compile(r'bug[\s:#]+(\d{3,7})\b', re.I), r'https://bugzilla.mozilla.org/show_bug.cgi?id=\1'),
 )
 

--- a/weeklyupdates/templates/common.xhtml
+++ b/weeklyupdates/templates/common.xhtml
@@ -73,10 +73,8 @@ mozilla_site = cherrypy.request.app.config['weeklyupdates'].get('mozilla',True)
         </div>
       </py:when>
       <py:otherwise>
-			<h4 py:if="showuser" class="postuser"><a href="${genlink('user', post.userid)}">
-          <py:if test="show_avatar">
-          <img class="avatar" src="https://avatars.io/email/${post.userid}" />
-          </py:if>
+        <h4 py:if="showuser" class="postuser"><a href="${genlink('user', post.userid)}">
+          <img py:if="show_avatar" class="avatar" src="https://avatars.io/email/${post.userid}" />
           ${post.userid}</a>
           <small py:if="showdate" class="pull-right" title="Posted on ${post.postdate.isoformat()}">
             <span class="glyphicon glyphicon-time"></span>

--- a/weeklyupdates/templates/common.xhtml
+++ b/weeklyupdates/templates/common.xhtml
@@ -6,8 +6,9 @@ import cherrypy
 import human
 import json
 
-title = cherrypy.request.app.config['weeklyupdates'].get('title',
-                                        'Mozilla Status Board')
+title = cherrypy.request.app.config['weeklyupdates'].get('title','Mozilla Status Board')
+show_avatar = cherrypy.request.app.config['weeklyupdates'].get('avatar',True)
+
 ?>
 <div xmlns="http://www.w3.org/1999/xhtml"
      xmlns:py="http://genshi.edgewall.org/"
@@ -71,8 +72,11 @@ title = cherrypy.request.app.config['weeklyupdates'].get('title',
         </div>
       </py:when>
       <py:otherwise>
-        <h4 py:if="showuser" class="postuser"><a href="${genlink('user', post.userid)}">
-          <img class="avatar" src="https://avatars.io/email/${post.userid}" />${post.userid}</a>
+			<h4 py:if="showuser" class="postuser"><a href="${genlink('user', post.userid)}">
+          <py:if test="show_avatar">
+          <img class="avatar" src="https://avatars.io/email/${post.userid}" />
+          </py:if>
+          ${post.userid}</a>
           <small py:if="showdate" class="pull-right" title="Posted on ${post.postdate.isoformat()}">
             <span class="glyphicon glyphicon-time"></span>
             ${human.date(post.postdate, asdays=True)}

--- a/weeklyupdates/templates/common.xhtml
+++ b/weeklyupdates/templates/common.xhtml
@@ -5,6 +5,9 @@ from urllib import quote, urlencode
 import cherrypy
 import human
 import json
+
+title = cherrypy.request.app.config['weeklyupdates'].get('title',
+                                        'Mozilla Status Board')
 ?>
 <div xmlns="http://www.w3.org/1999/xhtml"
      xmlns:py="http://genshi.edgewall.org/"
@@ -20,7 +23,7 @@ import json
 
   <body py:match="body" class="normalcols" py:attrs="select('@*')">
     <div class="header">
-      <h3><a href="${genlink('')}">Mozilla Status Board</a>
+      <h3><a href="${genlink('')}">${title}</a>
         <py:if test="loginid is not None">
           <span class="pull-right small text-muted hidden-xs">${loginid}</span>
         </py:if>

--- a/weeklyupdates/templates/common.xhtml
+++ b/weeklyupdates/templates/common.xhtml
@@ -8,6 +8,7 @@ import json
 
 title = cherrypy.request.app.config['weeklyupdates'].get('title','Mozilla Status Board')
 show_avatar = cherrypy.request.app.config['weeklyupdates'].get('avatar',True)
+mozilla_site = cherrypy.request.app.config['weeklyupdates'].get('mozilla',True)
 
 ?>
 <div xmlns="http://www.w3.org/1999/xhtml"

--- a/weeklyupdates/templates/feed.xml
+++ b/weeklyupdates/templates/feed.xml
@@ -16,7 +16,7 @@ import datetime
   <updated py:if="not len(feedposts)">${feeddate(datetime.datetime.utcnow())}</updated>
 
   <author>
-    <name>Mozilla Status Board</name>
+    <name>${title}</name>
   </author>
 
   <entry py:for="post in feedposts">

--- a/weeklyupdates/templates/index.xhtml
+++ b/weeklyupdates/templates/index.xhtml
@@ -5,7 +5,7 @@
   <xi:include href="common.xhtml"/>
 
   <head>
-    <title>Mozilla Status Board</title>
+    <title>${title}</title>
     <link href="${genlink('feed')}" type="application/atom+xml" rel="alternate" title="Recent Posts (All Users)"/>
     <link py:if="loginid is not None"
           href="${genlink('user', loginid, 'teamposts', 'feed')}"

--- a/weeklyupdates/templates/markup.xhtml
+++ b/weeklyupdates/templates/markup.xhtml
@@ -15,7 +15,9 @@
     <p>The following extras are supported:
       <ul>
 	<li>Automatic linkifying: Anything that looks like a link starting with http: or https: will automatically be made into a link.</li>
+  <py:if test="mozilla_site">
 	<li>Automatic bug linkifying. Things like "bug 12345" will be auto-linked to bugzilla.mozilla.org.</li>
+  </py:if>
 	<li>Cuddled lists: a new line that starts with a start will be made into a list (normal markdown requires an intermediate blank line).</li>
 	<li>Disabled _emphasis_. Because MDN links and code snippets often contain embedded underscores, this was causing confusion and is disabled.</li>
       </ul>

--- a/weeklyupdates/templates/markup.xhtml
+++ b/weeklyupdates/templates/markup.xhtml
@@ -15,9 +15,7 @@
     <p>The following extras are supported:
       <ul>
 	<li>Automatic linkifying: Anything that looks like a link starting with http: or https: will automatically be made into a link.</li>
-  <py:if test="mozilla_site">
-	<li>Automatic bug linkifying. Things like "bug 12345" will be auto-linked to bugzilla.mozilla.org.</li>
-  </py:if>
+	<li py:if="mozilla_site">Automatic bug linkifying. Things like "bug 12345" will be auto-linked to bugzilla.mozilla.org.</li>
 	<li>Cuddled lists: a new line that starts with a start will be made into a list (normal markdown requires an intermediate blank line).</li>
 	<li>Disabled _emphasis_. Because MDN links and code snippets often contain embedded underscores, this was causing confusion and is disabled.</li>
       </ul>

--- a/weeklyupdates/templates/posts.xhtml
+++ b/weeklyupdates/templates/posts.xhtml
@@ -5,7 +5,7 @@
   <xi:include href="common.xhtml"/>
 
   <head>
-    <title>Mozilla Status Board: Recent Posts (All Users)</title>
+    <title>${title}: Recent Posts (All Users)</title>
     <link href="${genlink('feed')}" type="application/atom+xml"
           rel="alternate" title="Posts Feed (All Users)"/>
   </head>

--- a/weeklyupdates/templates/project.xhtml
+++ b/weeklyupdates/templates/project.xhtml
@@ -5,7 +5,7 @@
   <xi:include href="common.xhtml"/>
 
   <head>
-    <title>Mozilla Status Board: Project: ${projectname}</title>
+    <title>${title}: Project: ${projectname}</title>
     <link href="${genlink('project', projectname, 'feed')}" type="application/atom+xml"
           rel="alternate" title="All project posts"/>
   </head>

--- a/weeklyupdates/templates/teamposts.xhtml
+++ b/weeklyupdates/templates/teamposts.xhtml
@@ -5,7 +5,7 @@
   <xi:include href="common.xhtml"/>
 
   <head>
-    <title>Mozilla Status Board: User Team: ${userid}</title>
+    <title>${title}: User Team: ${userid}</title>
     <link href="${genlink('user', userid, 'teamposts/feed')}" type="application/atom+xml"
           rel="alternate" title=" posts"/>
   </head>

--- a/weeklyupdates/templates/user.xhtml
+++ b/weeklyupdates/templates/user.xhtml
@@ -5,7 +5,7 @@
   <xi:include href="common.xhtml"/>
 
   <head>
-    <title>Mozilla Status Board: ${userid}</title>
+    <title>${title}: ${userid}</title>
     <link href="${genlink('user', userid, 'posts/feed')}" type="application/atom+xml"
           rel="alternate" title="User posts"/>
     <link href="${genlink('user', userid, 'teamposts', 'feed')}" type="application/atom+xml"

--- a/weeklyupdates/templates/userposts.xhtml
+++ b/weeklyupdates/templates/userposts.xhtml
@@ -5,7 +5,7 @@
   <xi:include href="common.xhtml"/>
 
   <head>
-    <title>Mozilla Status Board: All Posts By ${userid}</title>
+    <title>${title}: All Posts By ${userid}</title>
     <link href="${genlink('user', userid, 'posts/feed')}" type="application/atom+xml"
           rel="alternate" title="User posts"/>
   </head>


### PR DESCRIPTION
This changes allows the execution of the services without references to Mozilla. These changes are quite useful in order to use this software in other deployments. With this patch:
- the current default behavior of the software is not modified
- explicit references to Mozilla (URLs, List-id, iterations, bugs ... ) can be disabled or rewritten by config file
